### PR TITLE
Build node-12 binary in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ after_success:
 - npm run coveralls
 - docker-compose up build-linux-node-10
 - docker-compose up build-linux-node-11
+- docker-compose up build-linux-node-12
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Added `docker-compose up build-linux-node-12` to .travis.yml

Could you please publish a new version on npm as well to make the "args[4]->NumberValue();" fix available?
