### PR TITLE
Fix travis ci build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- '12'
+- '13'
 env:
   - CXX=g++-4.8
 addons:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "coveragehtml": "nyc report -r html",
     "precoveragehtml": "npm run coverage",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
-    "test": "ava test/*"
+    "test": "ava test/*",
+    "preinstall": "true",
+    "install": "node-pre-gyp install --fallback-to-build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use `node_js: 13` to repair travis ci build.