### PR TITLE
Build on amd64 and arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 sudo: false
+arch:
+  - amd64
+  - arm64
 node_js:
 - '13'
 env:


### PR DESCRIPTION
Building binaries for arm64 might help on new Apple Silicon (m1) environments.