### PR TITLE
Fix install on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "precoveragehtml": "npm run coverage",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "test": "ava test/*",
-    "preinstall": "true",
     "install": "node-pre-gyp install --fallback-to-build"
   },
   "repository": {


### PR DESCRIPTION
Fix the following error when trying to install on Windows:
```
the package 'true' is not recognized as an internal or external command
```